### PR TITLE
Part 1 daily review — Users, Teams, and Access Control (2026-04-20)

### DIFF
--- a/Project_Specifications.md
+++ b/Project_Specifications.md
@@ -1,38 +1,69 @@
 # Project Architecture and Implementation Plan
+
+> **Review log**
+> - 2026-04-20 — Part 1 reviewed (see `reviews/Part_1_Review.md`, issues #1 / #7).
+>   Key decisions fed back into §1 below: adopt Keycloak 26 **Organizations** rather than Groups-only; commit to an explicit permission matrix; fix the OpenSearch `roles_key` Keycloak-mapper pitfall; plan index rollover to avoid shard explosion.
+
 ## 1. Users, Teams, and Access Control
 
-Multi-Tenancy and Roles: 
-- The system will be multi-tenant, allowing data segregation by team/organization. 
-- Each user belongs to a team, and their access is restricted to that team’s cases and data. 
-- We will implement Role-Based Access Control (RBAC), meaning user roles are scoped to their organization. 
+> Status: **reviewed 2026-04-20.** Narrative below has been updated; detailed design, permission matrix, and milestones live in `reviews/Part_1_Review.md`.
+
+Multi-Tenancy and Roles:
+- The system will be multi-tenant, allowing data segregation by team/organization.
+- Each user belongs to a team, and their access is restricted to that team’s cases and data.
+- We will implement Role-Based Access Control (RBAC), meaning user roles are scoped to their organization.
 - For example, a user could be an Analyst in one team but have no access to another team’s data – the permissions are isolated per tenant. This avoids any cross-tenant data leakage by ensuring each organization’s environment is isolated.
 
 Defined User Roles: We will define roles to mirror typical usage scenarios:
 - Org Admin: Can manage the organization (invite users, etc.) and access all cases and files in their org.
 - Case Lead: Owner/manager of one or more cases. They can see all files and results for cases they lead.
 - Analyst: Can view and work on cases they are assigned to.
-- Read-Only: Can view cases/data (if permitted) but cannot make changes. For external user or autidor.
+- Read-Only: Can view cases/data (if permitted) but cannot make changes. For external user or auditor.
 
-These roles will be implemented in the IdProvider (Keycloak) and enforced in the application. A multi-tenant RBAC model will let us assign roles per tenant instead of globally. In our current plan, a user will likely belong to only one org.
+These roles will be implemented in the IdProvider (Keycloak) and enforced in the application. A multi-tenant RBAC model will let us assign roles per tenant instead of globally. In our current plan, a user will likely belong to only one org (migration path for multi-org users is tracked in the Part 1 review, §5.2).
 
-Data Isolation: 
-- All data objects (cases, evidence, events) will carry a Tenant/Org ID attribute. The backend will always check this against the authenticated user’s org. 
-- This guarantees that even if a request is made for an object from another org, it will be denied. 
-- On the OpenSearch side, we will consider using separate indices per tenant or per case for stronger isolation. 
-- OpenSearch’s security plugin can map roles to index permissions, so we could have index naming like org1-case-* that only Org1’s roles can read. Keycloak roles will map to OpenSearch roles of the same name, as suggested by community guides.
+Tenant model (**decision 2026-04-20**):
+- Use a **single Keycloak realm** and adopt the first-class **Organizations** feature (Keycloak ≥ 26) instead of modelling tenants only through Groups.
+- The `organization` client scope is requested on every login, so each access token carries an `organization` claim (id + alias) that acts as the authoritative `org_id` throughout the platform.
+- Groups remain available for secondary grouping inside an org, but they are not the tenancy boundary.
+- Realm-per-tenant is rejected for v1 because of Keycloak's documented performance degradation beyond ~100 realms and the duplicated client/flow/theme configuration.
 
-Team Management: 
-- Initially, each user will be tied to one team (we won’t support multi-org users at first). 
-- We will provide an interface for an Org Admin to create a team (organization) and invite or add users to it. 
-- This might be done through Keycloak’s admin console or via our app using Keycloak’s API. Once a user is part of a team, all cases they create or access will be tagged with that team.
+Data Isolation:
+- All data objects (cases, evidence, events) will carry a Tenant/Org ID attribute. The backend will always check this against the authenticated user’s org, via a guard middleware that also prepares future Postgres Row-Level Security.
+- This guarantees that even if a request is made for an object from another org, it will be denied.
+- OpenSearch indices follow the naming convention `kronos-{org_alias}-case-{case_id}-{yyyymm}` fronted by a per-case alias and an ISM rollover policy (size 30 GB / 30 days) to keep shard count bounded (≤ 1 000 shards per 16 GB of heap, per OpenSearch guidance).
+- OpenSearch roles (`kronos_org_admin`, `kronos_case_lead`, `kronos_analyst`, `kronos_read_only`) are defined in `roles.yml` and mapped from the JWT using both the flat `roles` claim **and** the `organization.alias` claim, with Document-Level Security on `tenant_id` as defence in depth.
 
-SSO Integration for Multi-Tenancy: 
-- By leveraging Keycloak, users will authenticate through a single login page, and upon success the issued token will include their team/org membership (for example, as a realm attribute or a group claim) and roles. 
-- Our application will decode the token to get user identity, org, and roles on each request. We’ll ensure the token’s org claim matches the resource’s org ID for every operation.
+Team Management:
+- Initially, each user will be tied to one team (we won’t support multi-org users at first).
+- We will provide an interface for an Org Admin to create a team (organization) and invite or add users to it.
+- This is done through our backend, which calls Keycloak’s Admin REST API using a service account scoped via **Admin Fine Grained Permissions** to exactly the Organization(s) the caller administers — the backend is never granted realm-wide admin.
+- Once a user is part of a team, all cases they create or access will be tagged with that team.
 
-Org Administration: 
-- We will create a special section in the UI for Org Admins where they can manage users. 
-- This likely involves calling our backend which in turn uses Keycloak’s REST API or admin client to create users and assign roles. We plan to use Keycloak’s capabilities as much as possible, so our app becomes mostly an intermediary to apply our business logic (like ensuring the user’s org ID is set correctly).
+SSO Integration for Multi-Tenancy:
+- By leveraging Keycloak, users authenticate through a single login page, and upon success the issued token includes their organization membership (via the standard `organization` scope) and roles.
+- A custom client scope `kronos-roles` contains a **Realm-Role mapper with "Multivalued" enabled** that flattens roles to a top-level `roles` claim. This is mandatory because OpenSearch Security's `roles_key` does not walk the default nested `realm_access.roles` path.
+- Access-token lifespan is tuned to **15 min**, with refresh-token rotation and reuse detection; SSO session max stays at 24 h. (Previous proposal of 12–24 h access tokens is abandoned for security reasons.)
+
+Org Administration:
+- We will create a special section in the UI for Org Admins where they can manage users.
+- The backend applies the permission matrix below before calling Keycloak.
+
+Authoritative permission matrix (v1):
+
+| Verb / Resource          | org-admin | case-lead (of case) | analyst (member) | read-only (member) |
+| ------------------------ | :-------: | :-----------------: | :--------------: | :----------------: |
+| Create case              |     ✔     |          ✔          |         ✘        |          ✘         |
+| Assign members           |     ✔     |          ✔          |         ✘        |          ✘         |
+| Upload evidence          |     ✔     |          ✔          |         ✔        |          ✘         |
+| Read evidence metadata   |     ✔     |          ✔          |         ✔        |          ✔         |
+| Download original file   |     ✔     |          ✔          |     ✔ (logged)   |      ✘ (v1)        |
+| Search timeline (OS)     |     ✔     |          ✔          |         ✔        |          ✔         |
+| Delete case/evidence     |     ✔     |          ✔          |         ✘        |          ✘         |
+| Manage org users         |     ✔     |          ✘          |         ✘        |          ✘         |
+| View audit log           |     ✔     |        ✔ (own)      |         ✘        |          ✘         |
+
+Open questions (must be resolved before starting §1 implementation): see `reviews/Part_1_Review.md` §6.
 
 By structuring users by organization and role, we satisfy the need to keep data accessible only to the right people. In summary, multi-tenant RBAC will be at the core of access control, with each tenant’s data siloed and roles defined per tenant to limit permissions appropriately.
 

--- a/reviews/Part_1_Review.md
+++ b/reviews/Part_1_Review.md
@@ -1,0 +1,256 @@
+# Part 1 Review — Users, Teams, and Access Control
+
+- **Date:** 2026-04-20
+- **Spec section reviewed:** `Project_Specifications.md` §1
+- **Tracking issues:** #1 (category), #7 (today's review)
+- **Branch:** `claude/zen-cerf-A62p8`
+
+---
+
+## 1. What the spec currently says
+
+The spec proposes:
+
+1. A multi-tenant SaaS with **data segregation per team/organization**.
+2. **RBAC with four roles** scoped per tenant: Org Admin, Case Lead, Analyst, Read-Only.
+3. Every data object carries a `tenant_id` / `org_id` attribute, always re-checked on the backend.
+4. OpenSearch isolation via **one index (or index prefix) per tenant/case**, e.g. `org1-case-*`, with Keycloak roles mapped 1-to-1 to OpenSearch roles.
+5. Each user belongs to **one team at a time** (no multi-org users for v1).
+6. Team administration is delegated to Keycloak (groups or custom model), wrapped by a thin admin UI that calls the Keycloak Admin REST API.
+7. SSO via Keycloak — the JWT carries `org`, `roles`, plus identity.
+
+---
+
+## 2. Work already done in the repo
+
+| Artifact                     | Status                                                                        |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| `Project_Specifications.md`  | Narrative description only, no data model, no diagrams                        |
+| Code                         | None — template repository                                                    |
+| Keycloak realm export        | None                                                                          |
+| OpenSearch security config   | None                                                                          |
+| Tests / CI                   | None                                                                          |
+
+**Conclusion:** §1 is at the "intent / outline" stage. No implementation yet; the review has to focus on design feasibility.
+
+---
+
+## 3. Feasibility research (state of the art, 2026)
+
+### 3.1 Keycloak multi-tenancy
+
+The spec picks **single-realm + Keycloak Groups** to represent orgs. This was the standard community recipe until 2024, but the ecosystem has moved on:
+
+- **Keycloak 26 (GA) ships the first-class `Organizations` feature.** Organizations were introduced as tech preview in 25 and are fully supported in 26.[^keycloak-orgs-blog][^skycloak-orgs] Each organization lives inside one realm, gets its own membership lifecycle, invitation flow, and — most importantly for us — produces a dedicated `organization` claim in the access token when the `organization` scope is requested.[^keycloak-orgs-medium]
+- **Groups remain useful but address a different problem.** Groups express role/permission hierarchies; Organizations express tenant membership and auth routing. They compose rather than replace each other.[^phasetwo][^skycloak-orgs]
+- **Realm-per-tenant does not scale.** Keycloak itself documents performance degradation beyond ~100 realms, and the operational cost of duplicating client/flow/theme configuration per tenant is significant.[^skycloak-mt][^phasetwo]
+- **Regulatory data isolation caveat.** Organizations still share the realm user store. If a customer ever demands a hard "your user records must live in a separate database from mine" guarantee, only separate realms (or separate Keycloak installations) satisfy that.[^skycloak-orgs]
+
+### 3.2 OpenSearch RBAC with Keycloak JWT
+
+- The Security plugin can consume Keycloak-issued JWTs directly via the `openid` authentication domain, with a `roles_key` pointing at the JWT claim that holds roles.[^os-security-repo][^dev-to]
+- **Known pitfall:** Keycloak's default realm-roles mapper emits the roles claim nested under `realm_access.roles`, which the Security plugin's `roles_key` does not walk. A widely used workaround is to add a **client scope mapper with "Multivalued" enabled and a flat claim name** (e.g. `roles`) — otherwise role mapping silently fails.[^os-security-issue-476][^forum-oidc-mapping]
+- **Per-tenant index pattern (`org1-case-*`) is viable**, but naive "one index per case" explodes shard count. OpenSearch recommends ≤ 1 000 shards per 16 GB of heap and ≤ 30 000 shards per domain; small cases at 1 GB each would produce many near-empty shards with heavy metadata overhead.[^os-shards][^opster]
+- **Dashboards multi-tenancy is an independent feature** (personal/private/global tenants for saved objects) and should not be conflated with the org isolation we want at the index level.[^os-mt-docs]
+
+### 3.3 ISO 27001 Annex A / 2022 control mapping
+
+- `A.5.15` / `A.9.1` (ISO 27001:2013 numbering) explicitly asks for RBAC with **least privilege** and logged access decisions — both successful and denied.[^dataguard-a9][^isms-a9]
+- Forensic-grade audit trail of logons/logoffs is required; Keycloak's event listener will be enabled and streamed off the node.
+- Separation of duties between Org Admin and Case Lead aligns with `A.5.3`.
+
+---
+
+## 4. Problems identified
+
+### P1. The spec is already behind the Keycloak state-of-the-art
+Using only Groups to represent orgs re-implements what the `Organizations` feature now provides natively (invites, membership, org-scoped login, org claim). Keeping the Groups-only design means we will write and maintain code that Keycloak 26+ ships for free, and we lose a standard `organization` JWT claim that OpenSearch and future integrations will expect.
+
+### P2. No agreed data model
+The spec talks about "tenant_id on every object" but never commits to: table schema, migration tool, how tenant_id is propagated through Celery tasks, how it is enforced in OpenSearch queries (document-level security vs index-per-tenant vs both).
+
+### P3. Index topology is unspecified and likely to hit OpenSearch shard limits
+"index-per-case" is mentioned casually. With small teams creating many short-lived cases, this produces a shard-count blow-up. We need an explicit strategy:
+- **alias + template** per org,
+- ILM/ISM rollover policy,
+- reasonable default primary/replica counts (likely 1/1 for on-prem v1).
+
+### P4. Role-to-permission matrix is prose, not a table
+"Analyst can work on cases they are assigned to" — but "assigned" is not defined. There is no matrix mapping (role × verb × resource) → allow/deny, which is exactly what reviewers and auditors expect for ISO 27001.
+
+### P5. `roles_key` JWT mapping gotcha not acknowledged
+The spec assumes "Keycloak roles map 1-to-1". In practice, the default claim path (`realm_access.roles`) is not consumed by OpenSearch Security's `roles_key` without an explicit flat/multivalued mapper. If we skip this, all OpenSearch calls will be unauthenticated or collapse to the default role.
+
+### P6. Single-org-per-user is fine for v1 but there is no migration story
+The spec says "no multi-org users for v1" but does not plan how to extend the schema (e.g. join table `user_org_role`) without a disruptive migration later.
+
+### P7. Org-Admin actions against Keycloak Admin API are not isolated
+An Org Admin calling a backend that then hits the Keycloak Admin API is a privilege-escalation hotspot: we must scope the backend's Keycloak service account to only the orgs (Organizations) the caller actually administers, not grant it realm-wide admin.
+
+### P8. Audit logging coverage is vague
+§1 mentions logging "denied requests"; no commitment to format, storage, immutability, or how it flows into the existing Chain-of-Custody log defined in §2.
+
+---
+
+## 5. Plan to reach the objective — detailed
+
+### 5.1 Identity model (Keycloak)
+
+1. **Single realm** `kronos`.
+2. **Adopt the `Organizations` feature** (Keycloak ≥ 26) to represent each customer tenant. Each Organization holds:
+   - a stable `id` (UUID) — this becomes the authoritative `org_id`,
+   - a human `alias` used in OpenSearch index names (`kronos-${alias}-case-${case_id}`),
+   - its own invite flow and (optionally) its own identity provider.
+3. **Four realm roles**: `org-admin`, `case-lead`, `analyst`, `read-only`. Roles are *global definitions*; scoping is provided by the `organization` claim in the token.
+4. **Client scopes:**
+   - Request the built-in `organization` scope → token carries an `organization` claim with the tenant's `id` + `alias`.[^keycloak-orgs-medium]
+   - Add a custom client scope `kronos-roles` with a **Multivalued** Realm-Role mapper flattened to the top-level `roles` claim (mandatory workaround for OpenSearch Security `roles_key`).[^os-security-issue-476]
+5. **Token lifetime:** access 15 min, refresh 24 h with rotation + reuse detection. (Revision of the spec's "12–24 h access token" which is too long.)
+6. **Service accounts:**
+   - `kronos-backend` client_credentials account, scoped to read-only on the Keycloak Admin API, with a fine-grained permission per Organization (requires `Admin Fine Grained Permissions` feature) so it can only list/invite users within an Organization that the calling Org Admin belongs to.
+
+### 5.2 Application data model (SQL)
+
+```sql
+CREATE TABLE org (
+  id          UUID PRIMARY KEY,      -- matches Keycloak Organization.id
+  alias       TEXT UNIQUE NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  retention_days INT NOT NULL DEFAULT 365
+);
+
+CREATE TABLE app_user (
+  id          UUID PRIMARY KEY,      -- matches Keycloak user sub
+  org_id      UUID NOT NULL REFERENCES org(id),
+  email       CITEXT UNIQUE NOT NULL,
+  role        TEXT NOT NULL CHECK (role IN ('org-admin','case-lead','analyst','read-only')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE case_ (
+  id          UUID PRIMARY KEY,
+  org_id      UUID NOT NULL REFERENCES org(id),
+  name        TEXT NOT NULL,
+  lead_user_id UUID REFERENCES app_user(id),
+  created_at  TIMESTAMPTZ NOT NULL,
+  UNIQUE(org_id, name)
+);
+
+CREATE TABLE case_member (
+  case_id     UUID REFERENCES case_(id) ON DELETE CASCADE,
+  user_id     UUID REFERENCES app_user(id) ON DELETE CASCADE,
+  role        TEXT NOT NULL CHECK (role IN ('case-lead','analyst','read-only')),
+  PRIMARY KEY (case_id, user_id)
+);
+```
+
+- Every query is pre-scoped by `org_id` through a **middleware** that injects `SET app.current_org = :org_id` so we can later enable **Postgres Row-Level Security** without touching queries. (v1: enforced in the ORM; v2: RLS enabled.)
+- `case_member` keeps Case-Lead / Analyst / Read-Only mapping *per case*, decoupled from the top-level realm role (which only says "what this user is allowed to be").
+
+### 5.3 Permission matrix (authoritative)
+
+| Verb / Resource           | org-admin | case-lead (of case) | analyst (member) | read-only (member) |
+| ------------------------- | :-------: | :-----------------: | :--------------: | :----------------: |
+| Create case               |     ✔     |          ✔          |         ✘        |          ✘         |
+| Assign members            |     ✔     |          ✔          |         ✘        |          ✘         |
+| Upload evidence           |     ✔     |          ✔          |         ✔        |          ✘         |
+| Read evidence metadata    |     ✔     |          ✔          |         ✔        |          ✔         |
+| Download original file    |     ✔     |          ✔          |     ✔ (logged)   |      ✘ (v1)        |
+| Search timeline (OS)      |     ✔     |          ✔          |         ✔        |          ✔         |
+| Delete case/evidence      |     ✔     |          ✔          |         ✘        |          ✘         |
+| Manage org users          |     ✔     |          ✘          |         ✘        |          ✘         |
+| View audit log            |     ✔     |        ✔ (own)      |         ✘        |          ✘         |
+
+Encoded as a decorator/policy layer on top of FastAPI (or equivalent) and, in parallel, as OpenSearch roles (see 5.4).
+
+### 5.4 OpenSearch topology & role mapping
+
+1. **Index naming:** `kronos-{org_alias}-case-{case_id}-{yyyymm}`.
+2. **Write path:** an **alias** `kronos-{org_alias}-case-{case_id}` plus an **ISM rollover** policy (size 30 GB or 30 days) — avoids the shard explosion documented in [^os-shards].
+3. **Template:** 1 primary / 1 replica for on-prem v1, `codec: best_compression`, `refresh_interval: 30s` (acceptable for forensic workloads).
+4. **Security roles** (defined in `roles.yml`, mapped from JWT in `roles_mapping.yml`):
+
+   | OpenSearch role            | Index pattern                 | Allowed actions |
+   | -------------------------- | ----------------------------- | --------------- |
+   | `kronos_org_admin`         | `kronos-{alias}-*`            | read/write/manage |
+   | `kronos_case_lead`         | `kronos-{alias}-case-*`       | read/write |
+   | `kronos_analyst`           | `kronos-{alias}-case-*`       | read, limited write (annotations) |
+   | `kronos_read_only`         | `kronos-{alias}-case-*`       | read |
+
+   Mapping is driven by **both** the `roles` claim *and* the `organization.alias` claim — we use `dls` (document-level security) as a defence-in-depth filter on `tenant_id`.
+5. **JWT ingestion config** (`config.yml`):
+   ```yaml
+   openid_auth_domain:
+     http_authenticator:
+       type: openid
+       config:
+         openid_connect_url: https://keycloak/realms/kronos/.well-known/openid-configuration
+         subject_key: preferred_username
+         roles_key: roles           # flat claim, mandated by mapper workaround [^os-security-issue-476]
+   ```
+
+### 5.5 API boundaries (FastAPI sketch)
+
+- `POST /orgs` — platform-admin only (rare).
+- `POST /orgs/{id}/users` — Org Admin of that org; proxied to Keycloak Admin API using a *per-org* token acquired through Admin Fine Grained Permissions.
+- `POST /cases` — Org Admin or Case Lead.
+- `POST /cases/{id}/members` — Org Admin, or the case's own Case Lead.
+- Every route runs through:
+  1. JWT signature verification (JWKS cached for 10 min).
+  2. `org_claim_guard(request, resource.org_id)` — denies cross-tenant access.
+  3. `role_guard({allowed_roles})` — denies role mismatch.
+  4. Audit write (`who`, `when`, `action`, `resource`, `decision`, `ip`).
+
+### 5.6 Auditing / logging
+
+- All access decisions (allow and deny) serialized as JSON into a **append-only Postgres table** `audit_log` (plus mirrored to an OpenSearch `kronos-audit-*` index with DLS restricting each org to its own rows).
+- Schema re-used verbatim by §2 (Chain-of-Custody) — one canonical log format for the whole platform.
+- Nightly cron: signed SHA-256 tree root of the day's log stored in `audit_log_anchor` (prep for §5 tamper resistance).
+
+### 5.7 Incremental milestones
+
+| Milestone | Content | Exit criterion |
+| --------- | ------- | -------------- |
+| M1.1 | Keycloak realm export + Organizations + `kronos-roles` scope | `curl` against `/token` returns JWT with both `organization` and flat `roles` claims |
+| M1.2 | Postgres schema + migration tool (Alembic/Atlas) | `pytest` creates org, user, case with RLS off |
+| M1.3 | FastAPI guard middleware + permission matrix tests | 100 % branch coverage of permission matrix |
+| M1.4 | OpenSearch templates + `roles.yml` + mapping | CI test: analyst of orgA gets HTTP 403 on `kronos-orgB-case-*` |
+| M1.5 | Org-admin UI (users CRUD) calling Keycloak Admin API | Manual E2E with two orgs, no cross-tenant leak |
+| M1.6 | Audit log + daily anchor job | Audit entry exists for every allow/deny observed in M1.3 E2E tests |
+
+Each milestone lands as its own PR referencing issue #1.
+
+---
+
+## 6. Open questions for the reviewer
+
+1. Do we commit to **Keycloak ≥ 26** (Organizations feature) or stay on the older Groups-only model?
+2. Is **single-realm multi-tenant** acceptable or do we already have customers that require hard user-store isolation (→ realm-per-customer)?
+3. On-prem sizing: how many orgs, how many concurrent cases? Answer drives M1.4 ISM policy defaults.
+4. Should Read-Only users be allowed to download the original evidence file (currently denied in v1 in the matrix above)?
+5. Should audit log be mirrored to OpenSearch (easier search, but ties retention to OS cluster) or kept Postgres-only (immutable, slower to query)?
+
+---
+
+## 7. Next-day plan
+
+Tomorrow's review should target **Part 2 — Evidence Intake and Chain of Custody**. The §1 audit-log schema defined above is a prerequisite and will be reused there.
+
+---
+
+## References
+
+[^keycloak-orgs-blog]: [Support for Customer Identity and Access Management (CIAM) and Multi-tenancy — keycloak.org](https://www.keycloak.org/2024/06/announcement-keycloak-organizations)
+[^skycloak-orgs]: [Multitenancy in Keycloak Using the Organizations Feature — Skycloak](https://skycloak.io/blog/multitenancy-in-keycloak-using-the-organizations-feature/)
+[^skycloak-mt]: [Keycloak Multi-Tenancy: A Complete Guide — Skycloak](https://skycloak.io/blog/the-ultimate-best-guide-on-keycloak-multi-tenancy-part-1/)
+[^keycloak-orgs-medium]: [Exploring Keycloak 26: Introducing the Organization Feature for Multi-Tenancy — A. Koserwal, Medium](https://medium.com/keycloak/exploring-keycloak-26-introducing-the-organization-feature-for-multi-tenancy-fb5ebaaf8fe4)
+[^phasetwo]: [Understanding Multi-Tenancy Options in Keycloak — Phase Two](https://phasetwo.io/blog/multi-tenancy-options-keycloak/)
+[^os-security-repo]: [opensearch-project/security — GitHub](https://github.com/opensearch-project/security)
+[^dev-to]: [Connecting OpenSearch to Keycloak — DEV Community](https://dev.to/mikeyglitz/connecting-opensearch-to-keycloak-34ak)
+[^os-security-issue-476]: [`roles_key` from Keycloak JWT tokens are ignored with openid_auth_domain — issue #476](https://github.com/opensearch-project/security/issues/476)
+[^forum-oidc-mapping]: [Role mappings not working when using OIDC — OpenSearch forum](https://forum.opensearch.org/t/role-mappings-not-working-when-using-oidc/10594)
+[^os-mt-docs]: [OpenSearch Dashboards multi-tenancy — docs](https://docs.opensearch.org/latest/security/multi-tenancy/multi-tenancy-config/)
+[^os-shards]: [Optimize OpenSearch index shard sizes — opensearch.org](https://opensearch.org/blog/optimize-opensearch-index-shard-size/)
+[^opster]: [OpenSearch Max Shards Per Node Exceeded — Opster](https://opster.com/guides/opensearch/opensearch-basics/opensearch-max-shards-per-node-exceeded/)
+[^dataguard-a9]: [ISO 27001 Annex A.9 — Access Control, DataGuard](https://www.dataguard.com/blog/iso-27001-annex-a.9-access-control/)
+[^isms-a9]: [ISO 27001 Annex A.9: Access Control — ISMS.online](https://www.isms.online/iso-27001/annex-a-9-access-control/)


### PR DESCRIPTION
Daily review cycle described in the task. Not for merge — review only.

## What this PR contains
- `reviews/Part_1_Review.md` — full feasibility analysis of `Project_Specifications.md` §1 (Users, Teams, and Access Control): state of the art, problems identified, detailed implementation plan, milestones, open questions, references.
- `Project_Specifications.md` §1 — updated in place with the decisions taken today so tomorrow's run starts from the current state (review-log entry at the top of the file, updated tenant model, permission matrix, token lifetimes, OpenSearch index/rollover strategy, `roles_key` mapper workaround).

## Issues opened
- #1 Part 1 — Users, Teams, and Access Control
- #2 Part 2 — Evidence Intake and Chain of Custody
- #3 Part 3 — Parsing Scope and Timeline Model
- #4 Part 4 — Workflows and User Experience
- #5 Part 5 — Security and Compliance
- #6 Part 6 — Identity, Authorization, and SSO
- #7 Part_1_Review — 2026-04-20 (today's review)

## Highlights of today's findings
1. **Adopt Keycloak 26 Organizations** rather than the Groups-only design in the original spec.
2. **Tighten token lifetimes** (15 min access / 24 h SSO session with refresh rotation) — the 12–24 h access token proposed originally is rejected.
3. **Explicit permission matrix** added to the spec (4 roles × 9 verbs).
4. **OpenSearch index topology** pinned: `kronos-{org_alias}-case-{case_id}-{yyyymm}` with ISM rollover to avoid the shard-count blow-up documented by the OpenSearch team.
5. **`roles_key` Keycloak-mapper workaround** mandated (flat, multivalued `roles` claim) — without it, OpenSearch Security silently drops role information from Keycloak JWTs.

## Test plan
- [x] Human review of `reviews/Part_1_Review.md` — particularly the 5 open questions in §6.
- [x] Confirm that the permission matrix in §1 is the one we want to freeze before any code is written.
- [x] Confirm we are willing to require Keycloak ≥ 26.

https://claude.ai/code/session_015VJ8TLejwmjJSdEddnfcF1