### PR TITLE
fix(integration): implement missing delete_by_id and fix asyncio teardown

### DIFF
--- a/src/adapter/repository/postgres_evidence.py
+++ b/src/adapter/repository/postgres_evidence.py
@@ -130,6 +130,17 @@ class PostgresEvidenceRepository(EvidenceRepository):
             for row in result:
                 yield self._from_row(row._asdict())
 
+    async def delete_by_id(self, evidence_id: uuid.UUID, org_id: uuid.UUID) -> bool:
+        """Delete evidence metadata scoped to org_id. Returns True if a row was deleted."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                evidence_table.delete().where(
+                    evidence_table.c.evidence_id == evidence_id,
+                    evidence_table.c.org_id == org_id,
+                )
+            )
+        return result.rowcount > 0
+
     # ------------------------------------------------------------------
     # Row ↔ domain mapping
     # ------------------------------------------------------------------

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,9 +32,9 @@ def postgres_engine():  # type: ignore[no-untyped-def]
             await PostgresEvidenceRepository.create_tables(engine)
             await PostgresAuditLogRepository.create_tables(engine)
 
-        asyncio.get_event_loop().run_until_complete(_setup())
+        asyncio.run(_setup())
         yield engine
-        asyncio.get_event_loop().run_until_complete(engine.dispose())
+        asyncio.run(engine.dispose())
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

- **`PostgresEvidenceRepository.delete_by_id` missing** — the `EvidenceRepository` ABC declared `delete_by_id` as abstract but the Postgres implementation never provided it, making the class uninstantiable. Added a `DELETE` statement scoped to `(evidence_id, org_id)` returning a boolean indicating whether a row was found.
- **`asyncio.get_event_loop()` broken at teardown** — the session-scoped `postgres_engine` fixture in `tests/integration/conftest.py` used `asyncio.get_event_loop().run_until_complete(...)` for both setup and teardown. In Python 3.12 the event loop is gone by the time teardown runs (after pytest-asyncio has closed it), raising `RuntimeError: There is no current event loop`. Replaced both calls with `asyncio.run()`.

## Test plan

- [ ] `pytest tests/integration/test_evidence_intake.py` — all 9 previously failing tests should now pass
- [ ] `pytest tests/integration/` — teardown error on `test_two_orgs_go_to_separate_indices` should be gone
- [ ] Overall integration coverage should climb back above 80%
- [ ] `mypy src/adapter/repository/postgres_evidence.py` — clean
- [ ] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DakExMUVrQw4YhZMydHMb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DakExMUVrQw4YhZMydHMb8)_