### PR TITLE
fix(integration): use NullPool to avoid cross-event-loop asyncpg reuse

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,9 +20,15 @@ def postgres_engine():  # type: ignore[no-untyped-def]
         import asyncio
 
         from sqlalchemy.ext.asyncio import create_async_engine
+        from sqlalchemy.pool import NullPool
 
         url = pg.get_connection_url().replace("psycopg2", "asyncpg")
-        engine = create_async_engine(url, echo=False)
+        # NullPool: the engine is session-scoped but pytest-asyncio runs each
+        # test in its own event loop. asyncpg connections are bound to the loop
+        # that created them, so a pooled connection reused across loops raises
+        # "another operation is in progress". NullPool opens a fresh connection
+        # on the current loop per operation and closes it after, avoiding reuse.
+        engine = create_async_engine(url, echo=False, poolclass=NullPool)
 
         # Create tables synchronously before yielding.
         async def _setup() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #24. After `delete_by_id` was implemented, the 9 `test_evidence_intake.py` tests got past instantiation and surfaced the next-layer bug:

```
asyncpg.InterfaceError: cannot perform operation: another operation is in progress
```

**Root cause:** the `postgres_engine` fixture is **session-scoped** (one connection pool for the whole run), but pytest-asyncio runs **each test in its own event loop**. asyncpg binds every connection to the loop that created it. A pooled connection created in test 1's loop, then checked back out and reused in test 2's loop, makes asyncpg refuse the operation.

**Fix:** create the engine with `poolclass=NullPool`. Each operation opens a fresh connection on the *current* running loop and closes it afterward, so no connection is ever reused across loops. This is the standard pattern for a session-scoped SQLAlchemy async engine driven by per-test event loops.

Not a Python 3.12 issue — 3.12 just surfaces this fixture design bug more reliably; the same code is fragile on 3.11.

## Test plan

- [ ] `pytest tests/integration/test_evidence_intake.py` — all 9 tests pass (no more `InterfaceError`)
- [ ] `pytest tests/integration/` — full suite green, coverage back above 80%
- [ ] `ruff check tests/integration/conftest.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DakExMUVrQw4YhZMydHMb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DakExMUVrQw4YhZMydHMb8)_