### PR TITLE
fix(keycloak): REST org provisioning (dev/prod/Helm) + Celery startup race

### DIFF
--- a/charts/kronos/files/provision_keycloak_org.sh
+++ b/charts/kronos/files/provision_keycloak_org.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Provision a Keycloak Organization via the Admin REST API (idempotent).
+#
+# WHY REST AND NOT REALM IMPORT:
+#   Keycloak 26.1/26.2 cannot import an `organizations` block via --import-realm
+#   (it writes org metadata onto the backing group outside the organization
+#   context guard and fails with "Can not update organization group"). Creating
+#   the organization through the Admin REST API uses the supported code path.
+#
+# This script is the single source of truth shared by the dev/prod
+# docker-compose `keycloak-init` services and the Helm provisioning Job.
+# It assumes the realm (and, for member linking, the users) already exist.
+#
+# Required env:
+#   KC_BASE            Keycloak base URL, e.g. http://keycloak:8080
+#   KC_REALM           Target realm, e.g. kronos
+#   KC_ADMIN_USER      Master-realm admin username
+#   KC_ADMIN_PASSWORD  Master-realm admin password
+#   ORG_ALIAS          Organization alias, e.g. kronos-dev
+#   ORG_NAME           Organization display name, e.g. "KronOS Dev"
+# Optional env:
+#   ORG_DESCRIPTION    Free-text description (default empty)
+#   ORG_DOMAIN         A single org domain; created as verified (default none)
+#   ORG_MEMBER_IDS     Space-separated user UUIDs to link as members (default none)
+set -eu
+
+: "${KC_BASE:?KC_BASE is required (e.g. http://keycloak:8080)}"
+: "${KC_REALM:?KC_REALM is required (e.g. kronos)}"
+: "${KC_ADMIN_USER:?KC_ADMIN_USER is required}"
+: "${KC_ADMIN_PASSWORD:?KC_ADMIN_PASSWORD is required}"
+: "${ORG_ALIAS:?ORG_ALIAS is required}"
+: "${ORG_NAME:?ORG_NAME is required}"
+ORG_DESCRIPTION="${ORG_DESCRIPTION:-}"
+ORG_DOMAIN="${ORG_DOMAIN:-}"
+ORG_MEMBER_IDS="${ORG_MEMBER_IDS:-}"
+
+extract_first_id() { grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4; }
+
+echo "provision_keycloak_org: realm=$KC_REALM org=$ORG_ALIAS base=$KC_BASE"
+
+# Wait for Keycloak to be reachable (portable across compose healthchecks and
+# k8s readiness; avoids needing a version-specific keycloak healthcheck).
+i=0
+until curl -sf -o /dev/null "$KC_BASE/realms/master/.well-known/openid-configuration"; do
+  i=$((i + 1))
+  if [ "$i" -ge 60 ]; then
+    echo "ERROR: Keycloak not reachable at $KC_BASE after ~5m" >&2
+    exit 1
+  fi
+  echo "waiting for Keycloak at $KC_BASE ($i/60)..."
+  sleep 5
+done
+
+TOKEN=$(curl -sf "$KC_BASE/realms/master/protocol/openid-connect/token" \
+  -d "client_id=admin-cli&grant_type=password&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASSWORD" \
+  | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: could not obtain admin token (check KC_ADMIN_USER / KC_ADMIN_PASSWORD)" >&2
+  exit 1
+fi
+
+# Fail clearly if the realm itself is missing — prod/Helm assume it pre-exists.
+if ! curl -sf -o /dev/null -H "Authorization: Bearer $TOKEN" "$KC_BASE/admin/realms/$KC_REALM"; then
+  echo "ERROR: realm '$KC_REALM' does not exist; provision the realm before the org" >&2
+  exit 1
+fi
+
+ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+
+if [ -z "$ORG_ID" ]; then
+  echo "Creating organization $ORG_ALIAS"
+  if [ -n "$ORG_DOMAIN" ]; then
+    DOMAINS="[{\"name\":\"$ORG_DOMAIN\",\"verified\":true}]"
+  else
+    DOMAINS="[]"
+  fi
+  curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations" \
+    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}"
+  ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+else
+  echo "Organization $ORG_ALIAS already exists"
+fi
+
+if [ -z "$ORG_ID" ]; then
+  echo "ERROR: organization $ORG_ALIAS could not be created or found" >&2
+  exit 1
+fi
+echo "Organization ID: $ORG_ID"
+
+# Link members (no-op when ORG_MEMBER_IDS is empty). PUT is idempotent.
+for USER_ID in $ORG_MEMBER_IDS; do
+  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members/$USER_ID" || true)
+  echo "Linked member $USER_ID -> HTTP $STATUS"
+done
+
+echo "provision_keycloak_org: complete"

--- a/charts/kronos/templates/keycloak/provision-org-configmap.yaml
+++ b/charts/kronos/templates/keycloak/provision-org-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.keycloak.provisionOrg.enabled }}
+# Ships the shared Keycloak org-provisioning script (mirrors
+# scripts/provision_keycloak_org.sh; chart-local copy because Helm .Files.Get
+# cannot reach outside the chart directory).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kronos.fullname" . }}-keycloak-org-init
+  namespace: kronos
+  labels:
+    {{- include "kronos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  provision_keycloak_org.sh: |
+{{ .Files.Get "files/provision_keycloak_org.sh" | indent 4 }}
+{{- end }}

--- a/charts/kronos/templates/keycloak/provision-org-job.yaml
+++ b/charts/kronos/templates/keycloak/provision-org-job.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.keycloak.provisionOrg.enabled }}
+# Post-install/upgrade hook that ensures the KronOS organization exists in
+# Keycloak via the Admin REST API — never via a realm-import organizations
+# block, which Keycloak 26.2 rejects with "Can not update organization group".
+# Assumes the realm already exists. Disabled by default (opt-in).
+# NOTE: egress from this pod to Keycloak must be permitted by your NetworkPolicy.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kronos.fullname" . }}-keycloak-org-init
+  namespace: kronos
+  labels:
+    {{- include "kronos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-org-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.keycloak.provisionOrg.backoffLimit | default 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kronos.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak-org-init
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: provision
+          image: {{ .Values.keycloak.provisionOrg.image | quote }}
+          command: ["sh", "/scripts/provision_keycloak_org.sh"]
+          env:
+            - name: KC_BASE
+              value: {{ .Values.keycloak.url | quote }}
+            - name: KC_REALM
+              value: {{ .Values.keycloak.realm | quote }}
+            - name: KC_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.provisionOrg.adminSecret | quote }}
+                  key: admin-user
+            - name: KC_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloak.provisionOrg.adminSecret | quote }}
+                  key: admin-password
+            - name: ORG_NAME
+              value: {{ .Values.keycloak.provisionOrg.org.name | quote }}
+            - name: ORG_ALIAS
+              value: {{ .Values.keycloak.provisionOrg.org.alias | quote }}
+            - name: ORG_DESCRIPTION
+              value: {{ .Values.keycloak.provisionOrg.org.description | quote }}
+            - name: ORG_DOMAIN
+              value: {{ .Values.keycloak.provisionOrg.org.domain | quote }}
+            - name: ORG_MEMBER_IDS
+              value: {{ .Values.keycloak.provisionOrg.org.memberIds | quote }}
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: {{ include "kronos.fullname" . }}-keycloak-org-init
+            defaultMode: 0555
+{{- end }}

--- a/charts/kronos/values-dev.yaml
+++ b/charts/kronos/values-dev.yaml
@@ -15,6 +15,15 @@ ingress:
 keycloak:
   url: http://keycloak:8080
   existingSecret: ""
+  provisionOrg:
+    enabled: true
+    adminSecret: kronos-keycloak-admin
+    org:
+      name: KronOS Dev
+      alias: kronos-dev
+      description: Default development organization
+      domain: kronos.dev
+      memberIds: ""
 
 opensearch:
   url: http://opensearch:9200

--- a/charts/kronos/values.yaml
+++ b/charts/kronos/values.yaml
@@ -85,6 +85,22 @@ keycloak:
   clientId: kronos-backend
   existingSecret: kronos-keycloak-secret
   secretKey: client-secret
+  # Ensure the KronOS organization exists via the Admin REST API (post-install
+  # hook Job). Orgs are NEVER created via a realm-import block — Keycloak 26.2
+  # rejects that with "Can not update organization group". Opt-in; the realm
+  # must already exist. The pod needs egress to keycloak.url.
+  provisionOrg:
+    enabled: false
+    image: curlimages/curl:latest
+    backoffLimit: 6
+    # Secret holding master-realm admin creds, keys: admin-user / admin-password
+    adminSecret: kronos-keycloak-admin
+    org:
+      name: KronOS
+      alias: kronos
+      description: KronOS organization
+      domain: ""        # optional; created as a verified org domain when set
+      memberIds: ""     # optional space-separated user UUIDs to link as members
 
 opensearch:
   url: https://opensearch:9200

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -107,10 +107,23 @@ services:
           -d "client_id=admin-cli&grant_type=password&username=admin&password=$ADMIN_PASS" \
           | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
 
-        # Find organization id
+        # Create the organization via the Admin REST API. It is intentionally NOT
+        # in the realm import: Keycloak 26.1/26.2 cannot import an organizations
+        # block (fails with "Can not update organization group"). The REST create
+        # path below is supported. Idempotent: skip if it already exists.
         ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
           "$BASE/admin/realms/$REALM/organizations?search=kronos-dev" \
           | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+        if [ -z "$ORG_ID" ]; then
+          echo "Creating organization kronos-dev"
+          curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+            "$BASE/admin/realms/$REALM/organizations" \
+            -d '{"name":"KronOS Dev","alias":"kronos-dev","enabled":true,"description":"Default development organization","domains":[{"name":"kronos.dev","verified":true}]}'
+          ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+            "$BASE/admin/realms/$REALM/organizations?search=kronos-dev" \
+            | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+        fi
 
         echo "Organization ID: $ORG_ID"
 
@@ -245,10 +258,13 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/1
       CELERY_RESULT_BACKEND: redis://redis:6379/2
       TSA_URL: http://tsa:318/api/v1/timestamp
+    # Gate on health: worker_init wiring (startup.py) connects to Postgres, so it
+    # must not start while "the database system is starting up", otherwise
+    # configure_dependencies() fails and beat tasks hit an unconfigured repo.
     depends_on:
-      - redis
-      - postgres
-      - minio
+      redis: { condition: service_healthy }
+      postgres: { condition: service_healthy }
+      minio: { condition: service_healthy }
     command: celery -A src.external.celery_app worker -Q q.parse.fast,q.parse.plaso,q.index -c 4 --loglevel=info
 
   celery-beat:
@@ -275,8 +291,8 @@ services:
       CELERY_RESULT_BACKEND: redis://redis:6379/2
       TSA_URL: http://tsa:318/api/v1/timestamp
     depends_on:
-      - redis
-      - postgres
+      redis: { condition: service_healthy }
+      postgres: { condition: service_healthy }
     command: celery -A src.external.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
 
   nginx:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -88,53 +88,28 @@ services:
       timeout: 10s
       retries: 10
 
+  # Creates the kronos-dev organization via the Admin REST API and links the
+  # three dev users. The org is NOT in the realm import because Keycloak 26.2
+  # cannot import an organizations block. Uses the shared provisioning script
+  # (scripts/provision_keycloak_org.sh) so dev/prod/Helm stay in sync.
   keycloak-init:
     image: curlimages/curl:latest
     depends_on:
       keycloak: { condition: service_healthy }
     restart: "no"
-    entrypoint:
-      - sh
-      - -c
-      - |
-        set -e
-        BASE=http://keycloak:8080
-        REALM=kronos
-        ADMIN_PASS=${KEYCLOAK_ADMIN_PASSWORD:-admin}
-
-        # Authenticate as admin
-        TOKEN=$(curl -sf "$BASE/realms/master/protocol/openid-connect/token" \
-          -d "client_id=admin-cli&grant_type=password&username=admin&password=$ADMIN_PASS" \
-          | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
-
-        # Create the organization via the Admin REST API. It is intentionally NOT
-        # in the realm import: Keycloak 26.1/26.2 cannot import an organizations
-        # block (fails with "Can not update organization group"). The REST create
-        # path below is supported. Idempotent: skip if it already exists.
-        ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-          "$BASE/admin/realms/$REALM/organizations?search=kronos-dev" \
-          | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-
-        if [ -z "$ORG_ID" ]; then
-          echo "Creating organization kronos-dev"
-          curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-            "$BASE/admin/realms/$REALM/organizations" \
-            -d '{"name":"KronOS Dev","alias":"kronos-dev","enabled":true,"description":"Default development organization","domains":[{"name":"kronos.dev","verified":true}]}'
-          ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-            "$BASE/admin/realms/$REALM/organizations?search=kronos-dev" \
-            | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
-        fi
-
-        echo "Organization ID: $ORG_ID"
-
-        # Add each user to the organization
-        for USER_ID in 10000000-0000-4000-8000-000000000001 10000000-0000-4000-8000-000000000002 10000000-0000-4000-8000-000000000003; do
-          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-            -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-            "$BASE/admin/realms/$REALM/organizations/$ORG_ID/members/$USER_ID" || true)
-          echo "Added user $USER_ID -> HTTP $STATUS"
-        done
-        echo "keycloak-init complete"
+    volumes:
+      - ../scripts/provision_keycloak_org.sh:/provision_keycloak_org.sh:ro
+    environment:
+      KC_BASE: http://keycloak:8080
+      KC_REALM: kronos
+      KC_ADMIN_USER: admin
+      KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      ORG_NAME: KronOS Dev
+      ORG_ALIAS: kronos-dev
+      ORG_DESCRIPTION: Default development organization
+      ORG_DOMAIN: kronos.dev
+      ORG_MEMBER_IDS: "10000000-0000-4000-8000-000000000001 10000000-0000-4000-8000-000000000002 10000000-0000-4000-8000-000000000003"
+    entrypoint: ["sh", "/provision_keycloak_org.sh"]
 
   clamav:
     image: clamav/clamav:stable

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -73,7 +73,9 @@ services:
       - ./opensearch/opensearch.yml:/usr/share/opensearch/config/opensearch.yml:ro
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    # 26.2 (not 26.0): the organization-id token claim (addOrganizationId) the
+    # backend's _extract_tenant requires only lands in 26.1+. Keep in sync with dev.
+    image: quay.io/keycloak/keycloak:26.2
     command: start
     environment:
       KC_DB: postgres
@@ -86,6 +88,29 @@ services:
       KC_FEATURES: organization,token-exchange,fgap-v2
     volumes:
       - ./certs:/certs:ro
+
+  # Ensures the KronOS organization exists via the Admin REST API (the same
+  # approach as dev) — never via a realm-import organizations block, which
+  # Keycloak 26.2 rejects with "Can not update organization group".
+  # Assumes the realm is already provisioned. ORG_MEMBER_IDS is empty in prod:
+  # real users join the org through the IdP / org domain, not by seeded ids.
+  keycloak-init:
+    image: curlimages/curl:latest
+    restart: "no"
+    depends_on:
+      - keycloak
+    volumes:
+      - ../scripts/provision_keycloak_org.sh:/provision_keycloak_org.sh:ro
+    environment:
+      KC_BASE: http://keycloak:8080
+      KC_REALM: kronos
+      KC_ADMIN_USER: ${KEYCLOAK_ADMIN:-admin}
+      KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      ORG_NAME: ${KRONOS_ORG_NAME:-KronOS}
+      ORG_ALIAS: ${KRONOS_ORG_ALIAS:-kronos}
+      ORG_DESCRIPTION: KronOS production organization
+      ORG_DOMAIN: ${KRONOS_ORG_DOMAIN:-}
+    entrypoint: ["sh", "/provision_keycloak_org.sh"]
 
   clamav:
     image: clamav/clamav:stable

--- a/docker/keycloak/kronos-realm.json
+++ b/docker/keycloak/kronos-realm.json
@@ -255,22 +255,7 @@
       "requiredActions": []
     }
   ],
-  "organizations": [
-    {
-      "id": "20000000-0000-4000-8000-000000000001",
-      "name": "KronOS Dev",
-      "alias": "kronos-dev",
-      "enabled": true,
-      "description": "Default development organization",
-      "domains": [
-        {
-          "name": "kronos.dev",
-          "verified": true
-        }
-      ],
-      "members": []
-    }
-  ],
+  "_comment_organizations": "The KronOS Dev organization is NOT defined here on purpose. Keycloak 26.1/26.2 cannot import an 'organizations' block via --import-realm: the import writes org metadata onto the backing group outside the organization-context guard and fails with 'Can not update organization group'. The org is instead created through the Admin REST API by the keycloak-init container (see docker-compose.dev.yml), which goes through the supported create path.",
   "passwordPolicy": "length(12) and notUsername and notEmail",
   "otpPolicyType": "totp",
   "otpPolicyAlgorithm": "HmacSHA1",

--- a/scripts/provision_keycloak_org.sh
+++ b/scripts/provision_keycloak_org.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Provision a Keycloak Organization via the Admin REST API (idempotent).
+#
+# WHY REST AND NOT REALM IMPORT:
+#   Keycloak 26.1/26.2 cannot import an `organizations` block via --import-realm
+#   (it writes org metadata onto the backing group outside the organization
+#   context guard and fails with "Can not update organization group"). Creating
+#   the organization through the Admin REST API uses the supported code path.
+#
+# This script is the single source of truth shared by the dev/prod
+# docker-compose `keycloak-init` services and the Helm provisioning Job.
+# It assumes the realm (and, for member linking, the users) already exist.
+#
+# Required env:
+#   KC_BASE            Keycloak base URL, e.g. http://keycloak:8080
+#   KC_REALM           Target realm, e.g. kronos
+#   KC_ADMIN_USER      Master-realm admin username
+#   KC_ADMIN_PASSWORD  Master-realm admin password
+#   ORG_ALIAS          Organization alias, e.g. kronos-dev
+#   ORG_NAME           Organization display name, e.g. "KronOS Dev"
+# Optional env:
+#   ORG_DESCRIPTION    Free-text description (default empty)
+#   ORG_DOMAIN         A single org domain; created as verified (default none)
+#   ORG_MEMBER_IDS     Space-separated user UUIDs to link as members (default none)
+set -eu
+
+: "${KC_BASE:?KC_BASE is required (e.g. http://keycloak:8080)}"
+: "${KC_REALM:?KC_REALM is required (e.g. kronos)}"
+: "${KC_ADMIN_USER:?KC_ADMIN_USER is required}"
+: "${KC_ADMIN_PASSWORD:?KC_ADMIN_PASSWORD is required}"
+: "${ORG_ALIAS:?ORG_ALIAS is required}"
+: "${ORG_NAME:?ORG_NAME is required}"
+ORG_DESCRIPTION="${ORG_DESCRIPTION:-}"
+ORG_DOMAIN="${ORG_DOMAIN:-}"
+ORG_MEMBER_IDS="${ORG_MEMBER_IDS:-}"
+
+extract_first_id() { grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4; }
+
+echo "provision_keycloak_org: realm=$KC_REALM org=$ORG_ALIAS base=$KC_BASE"
+
+# Wait for Keycloak to be reachable (portable across compose healthchecks and
+# k8s readiness; avoids needing a version-specific keycloak healthcheck).
+i=0
+until curl -sf -o /dev/null "$KC_BASE/realms/master/.well-known/openid-configuration"; do
+  i=$((i + 1))
+  if [ "$i" -ge 60 ]; then
+    echo "ERROR: Keycloak not reachable at $KC_BASE after ~5m" >&2
+    exit 1
+  fi
+  echo "waiting for Keycloak at $KC_BASE ($i/60)..."
+  sleep 5
+done
+
+TOKEN=$(curl -sf "$KC_BASE/realms/master/protocol/openid-connect/token" \
+  -d "client_id=admin-cli&grant_type=password&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASSWORD" \
+  | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: could not obtain admin token (check KC_ADMIN_USER / KC_ADMIN_PASSWORD)" >&2
+  exit 1
+fi
+
+# Fail clearly if the realm itself is missing — prod/Helm assume it pre-exists.
+if ! curl -sf -o /dev/null -H "Authorization: Bearer $TOKEN" "$KC_BASE/admin/realms/$KC_REALM"; then
+  echo "ERROR: realm '$KC_REALM' does not exist; provision the realm before the org" >&2
+  exit 1
+fi
+
+ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+  "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+
+if [ -z "$ORG_ID" ]; then
+  echo "Creating organization $ORG_ALIAS"
+  if [ -n "$ORG_DOMAIN" ]; then
+    DOMAINS="[{\"name\":\"$ORG_DOMAIN\",\"verified\":true}]"
+  else
+    DOMAINS="[]"
+  fi
+  curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations" \
+    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}"
+  ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+else
+  echo "Organization $ORG_ALIAS already exists"
+fi
+
+if [ -z "$ORG_ID" ]; then
+  echo "ERROR: organization $ORG_ALIAS could not be created or found" >&2
+  exit 1
+fi
+echo "Organization ID: $ORG_ID"
+
+# Link members (no-op when ORG_MEMBER_IDS is empty). PUT is idempotent.
+for USER_ID in $ORG_MEMBER_IDS; do
+  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members/$USER_ID" || true)
+  echo "Linked member $USER_ID -> HTTP $STATUS"
+done
+
+echo "provision_keycloak_org: complete"


### PR DESCRIPTION
## Symptom

`make dev` aborts:

```
keycloak-1 | ERROR: Failed to start server in (development) mode
keycloak-1 | ERROR: Can not update organization group
keycloak-1 exited with code 1
dependency failed to start: container docker-keycloak-1 exited (1)
make: *** [Makefile:10: dev] Error 1
```

## Root cause (origin)

**Fatal — Keycloak.** The `organizations` block in `kronos-realm.json` hits Keycloak **26.1/26.2's broken `--import-realm` path for organizations**: the import writes the org's metadata onto its backing group *outside* the organization-context guard in the JPA `GroupAdapter`, which throws `Can not update organization group` (same internal failure as [keycloak#31144](https://github.com/keycloak/keycloak/issues/31144), via the import path). The earlier fix (`2f00e27`) blamed a non-empty `members` array and emptied it — but the **log proves it still crashes with `members: []`**; importing the org instance at all is the trigger.

**Secondary — Celery race (non-fatal).** `celery-worker`/`celery-beat` `depend_on` Postgres without a health condition, so they boot while Postgres is still recovering (`FATAL: the database system is starting up`); wiring fails and the scheduled `anchor_audit_log` task hits an unconfigured repo → `RuntimeError: AuditLogRepository is not configured`.

## Fix — REST org creation everywhere (dev / prod / Helm)

The org is now **always** created through the Admin REST API (supported path), **never** via a realm-import block.

- **`scripts/provision_keycloak_org.sh`** — new shared, idempotent POSIX-sh provisioner: waits for Keycloak, verifies the realm exists, creates the org if absent, links any `ORG_MEMBER_IDS`. Single source of truth.
- **`kronos-realm.json`** — removed the `organizations` block (org-claim mapper / `organization` client scope stay).
- **`docker-compose.dev.yml`** — `keycloak-init` runs the shared script (was an inline duplicate); gated `celery-worker`/`celery-beat` on `service_healthy`.
- **`docker-compose.prod.yml`** — added a `keycloak-init` running the same script; **bumped Keycloak 26.0 → 26.2** because the org-id token claim (`addOrganizationId`, required by the backend's `_extract_tenant`) only exists in 26.1+.
- **`charts/kronos`** — opt-in post-install/upgrade hook **Job + ConfigMap** (chart-local copy of the script via `.Files.Get`) that ensures the org exists. Gated by `keycloak.provisionOrg.enabled` (off by default; enabled in `values-dev.yaml`); admin creds from `keycloak.provisionOrg.adminSecret`.

Safe because the backend reads `org_id` **dynamically from the token** (`keycloak_auth.py:150`) and lookups are **by alias**, so a server-generated org id is fine.

## Testing

Docker/helm/cluster aren't available in this environment, so I validated **statically**: `sh -n` on the script, YAML parse of both compose files and both values files, Helm `if/end` balance, and a simulated render of the ConfigMap `indent` (parses, script intact). The Keycloak diagnosis is grounded in the 26.2 source and the disproven `members` hypothesis. **Please confirm with a real `make dev` run** (and `helm template`/`helm lint` for the chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)