### PR TITLE
fix(dev): correct Keycloak 26 healthcheck (port 9000, no curl, KC_HEALTH_ENABLED)

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -83,14 +83,25 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_FEATURES: organization,token-exchange
+      # Expose /health/* on the management port (9000). Without this the health
+      # endpoints return 404 and the healthcheck below never passes.
+      KC_HEALTH_ENABLED: "true"
     volumes:
       - ./keycloak/kronos-realm.json:/opt/keycloak/data/import/kronos-realm.json:ro
     ports: ["8080:8080"]
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
-      interval: 20s
-      timeout: 10s
-      retries: 10
+      # The Keycloak 26 image ships no curl/wget, and /health lives on the
+      # management port 9000 (not 8080). Use bash's /dev/tcp (bash is present;
+      # kc.sh is a bash script) to probe GET /health/ready and match "200 OK".
+      test:
+        - CMD
+        - bash
+        - -c
+        - 'exec 3<>/dev/tcp/localhost/9000; printf "GET /health/ready HTTP/1.0\r\n\r\n" >&3; grep -q "200 OK" <&3'
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
 
   # Creates the kronos-dev organization via the Admin REST API and links the
   # three dev users. The org is NOT in the realm import because Keycloak 26.2


### PR DESCRIPTION
## Where the error comes from

This run got **much** further — the realm imports cleanly and Keycloak starts:

```
Realm 'kronos' imported
KC-SERVICES0032: Import finished successfully
Keycloak 26.2.5 ... started in 29.689s. Listening on: http://0.0.0.0:8080
```

But `make dev` still aborts:

```
Container docker-keycloak-1 Error dependency keycloak failed to start
dependency failed to start: container docker-keycloak-1 is unhealthy
```

Keycloak is **healthy in reality but fails its Docker healthcheck**, so `keycloak-init` (gated on `keycloak: service_healthy`) never starts. The healthcheck was `curl -f http://localhost:8080/health/ready`, which is wrong three ways for Keycloak 26 — confirmed against the docs:

1. **No curl/wget in the image** (removed intentionally) → the command can't run.
2. **`/health/*` is on the management port `9000`**, not `8080`.
3. The endpoints require **`KC_HEALTH_ENABLED=true`** (else 404).

This was always broken; the earlier import crashes just masked it (Keycloak never stayed up long enough to be probed).

## Fix

- Add `KC_HEALTH_ENABLED: "true"`.
- Replace the healthcheck with the Keycloak-maintainer-recommended container probe using bash's `/dev/tcp` (bash is present — `kc.sh` is a bash script): `GET /health/ready` on `:9000`, matching `200 OK`.
- Widen `retries` and add `start_period: 20s` for the ~30s cold start.

```yaml
test:
  - CMD
  - bash
  - -c
  - 'exec 3<>/dev/tcp/localhost/9000; printf "GET /health/ready HTTP/1.0\r\n\r\n" >&3; grep -q "200 OK" <&3'
```

## Testing

Static only (no Docker here): compose YAML parses; verified the `\r\n` stays a literal escape (single-quoted YAML) so bash `printf` emits the CRLF. Please re-run `make dev` — Keycloak should now go healthy and `keycloak-init` should provision the org.

Sources: [Keycloak — Tracking instance status with health checks](https://www.keycloak.org/observability/health), [keycloak#36537 (container HEALTHCHECK recommendation)](https://github.com/keycloak/keycloak/discussions/36537).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_