### PR TITLE
fix(dev): add start_period to Postgres healthcheck for first-init

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,10 +13,14 @@ services:
       # server listens only on the unix socket, so a socket-based pg_isready
       # reports healthy before :5432 accepts connections, and dependents
       # (backend/celery) then fail wiring with "Connect call failed ... 5432".
+      # start_period covers first-init (initdb + bootstrap + restart, ~45s on a
+      # fresh volume) during which the TCP check legitimately fails — without it
+      # the retries are exhausted before the real server is ready.
       test: ["CMD-SHELL", "pg_isready -U kronos -d kronos -h 127.0.0.1"]
       interval: 5s
       timeout: 3s
       retries: 10
+      start_period: 90s
 
   redis:
     image: redis:7-alpine

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -42,10 +42,13 @@ services:
     healthcheck:
       # -h 127.0.0.1 forces a TCP check so dependents don't start during the
       # first-time initdb bootstrap (socket-only) before :5432 is listening.
+      # start_period covers first-init, during which the TCP check legitimately
+      # fails — otherwise retries are exhausted before the server is ready.
       test: ["CMD-SHELL", "pg_isready -U kronos -h 127.0.0.1"]
       interval: 5s
       timeout: 3s
       retries: 10
+      start_period: 90s
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Where the error comes from

Keycloak is now `Healthy` and `keycloak-init` runs (`provision_keycloak_org: realm=kronos org=kronos-dev ...`) — that whole chain is fixed. The new abort is:

```
dependency failed to start: container docker-postgres-1 is unhealthy
```

…even though Postgres clearly comes up: `database system is ready to accept connections` at `18:54:46`.

This is the flip side of the TCP-honest healthcheck from #35. On a **fresh volume**, `initdb` + the socket-only bootstrap server + the restart take **~45s**, and during that window the honest `pg_isready -h 127.0.0.1` check *correctly* fails (no TCP listener yet). But there was **no `start_period`**, so every failing probe counted against `retries: 10` (×5s ≈ 50s) — the budget runs out right as the real server becomes ready, and compose declares it unhealthy. (The pre-#35 socket check only "passed" because it gave a false positive during bootstrap — exactly what we removed.)

## Fix

Add `start_period: 90s` to the Postgres healthcheck (dev + prod). During the start period, failing probes don't count toward `retries`, and the first success flips the container to healthy immediately — so first-init is tolerated while a genuinely broken DB still fails after the grace window.

## Testing

Static only (no Docker here): both compose files parse and show `start_period: 90s`. Please re-run `make dev` on a clean volume — Postgres should now reach healthy, and backend/celery should wire up behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_