### PR TITLE
fix(auth): allow 127.0.0.1 redirect URIs for kronos-frontend

### DIFF
--- a/docker/keycloak/kronos-realm.json
+++ b/docker/keycloak/kronos-realm.json
@@ -65,16 +65,20 @@
       "redirectUris": [
         "http://localhost:5173/*",
         "http://localhost/*",
-        "http://localhost:4173/*"
+        "http://localhost:4173/*",
+        "http://127.0.0.1/*",
+        "http://127.0.0.1:5173/*"
       ],
       "webOrigins": [
         "http://localhost:5173",
         "http://localhost",
-        "http://localhost:4173"
+        "http://localhost:4173",
+        "http://127.0.0.1",
+        "http://127.0.0.1:5173"
       ],
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "http://localhost:5173/*##http://localhost/*"
+        "post.logout.redirect.uris": "http://localhost:5173/*##http://localhost/*##http://127.0.0.1/*##http://127.0.0.1:5173/*"
       },
       "protocolMappers": [
         {


### PR DESCRIPTION
## Where the error comes from

The full stack is up and the SPA serves correctly (nginx returns `200` for `/`, the JS/CSS bundles, favicon). **Login** fails, and Keycloak says exactly why:

```
LOGIN_ERROR clientId="kronos-frontend" error="invalid_redirect_uri"
redirect_uri="http://127.0.0.1/silent-check-sso.html"
```

The app is being opened at **`http://127.0.0.1/`**, but the `kronos-frontend` client only whitelisted `localhost` origins:

```
redirectUris: http://localhost:5173/*, http://localhost/*, http://localhost:4173/*
```

Keycloak treats `127.0.0.1` and `localhost` as **different hosts**, so the `silent-check-sso.html` redirect to the `127.0.0.1` origin is rejected.

## Fix

Add `http://127.0.0.1/*` (and `:5173` for the Vite dev server) to the client's `redirectUris`, `webOrigins`, and `post.logout.redirect.uris`, so the dev SPA works whether opened at `localhost` or `127.0.0.1`.

## To pick it up

Keycloak uses `KC_DB: dev-mem` and re-imports the realm on every start, so just recreate Keycloak (no volume wipe needed):

```
docker compose -f docker/docker-compose.dev.yml up -d --force-recreate keycloak keycloak-init
```

(`keycloak-init` re-runs but is idempotent.) Then retry login at `http://127.0.0.1/`.

## Note

Cleaner long-term is to standardize on one host. The backend derives the token issuer from `KEYCLOAK_PUBLIC_URL=http://localhost:8080`, so the SPA→Keycloak hop still uses `localhost` regardless; this change just stops Keycloak rejecting the app's own `127.0.0.1` redirect. Using `http://localhost/` would also have worked without any change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_