### PR TITLE
fix(auth): link org members via POST (no PUT members endpoint in Keycloak 26)

### DIFF
--- a/charts/kronos/files/provision_keycloak_org.sh
+++ b/charts/kronos/files/provision_keycloak_org.sh
@@ -90,11 +90,15 @@ if [ -z "$ORG_ID" ]; then
 fi
 echo "Organization ID: $ORG_ID"
 
-# Link members (no-op when ORG_MEMBER_IDS is empty). PUT is idempotent.
+# Link members (no-op when ORG_MEMBER_IDS is empty). Keycloak 26 has no
+# PUT .../members/{id}; add via POST .../members with the user id as a quoted
+# JSON string body. 201/204 = added, 409 = already a member (both fine).
+# Members are required for the token's 'organization' claim to be emitted.
 for USER_ID in $ORG_MEMBER_IDS; do
-  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-    -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members/$USER_ID" || true)
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members" \
+    --data-raw "\"$USER_ID\"" || true)
   echo "Linked member $USER_ID -> HTTP $STATUS"
 done
 

--- a/scripts/provision_keycloak_org.sh
+++ b/scripts/provision_keycloak_org.sh
@@ -90,11 +90,15 @@ if [ -z "$ORG_ID" ]; then
 fi
 echo "Organization ID: $ORG_ID"
 
-# Link members (no-op when ORG_MEMBER_IDS is empty). PUT is idempotent.
+# Link members (no-op when ORG_MEMBER_IDS is empty). Keycloak 26 has no
+# PUT .../members/{id}; add via POST .../members with the user id as a quoted
+# JSON string body. 201/204 = added, 409 = already a member (both fine).
+# Members are required for the token's 'organization' claim to be emitted.
 for USER_ID in $ORG_MEMBER_IDS; do
-  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" \
-    -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members/$USER_ID" || true)
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations/$ORG_ID/members" \
+    --data-raw "\"$USER_ID\"" || true)
   echo "Linked member $USER_ID -> HTTP $STATUS"
 done
 


### PR DESCRIPTION
## Where the error comes from

Login now fully works (silent-SSO `200`, redirect to `/cases`). The backend then rejects every API call:

```
jwt_validation_failed: JWT is missing the 'organization' claim
GET /api/cases 401 Unauthorized
```

`_extract_tenant` requires the `organization` claim, and Keycloak only emits it for users who are **members** of an org. The org itself is created fine by `keycloak-init`, but the member-link step in the provisioning script used:

```
PUT /admin/realms/{realm}/organizations/{id}/members/{userId}
```

**That endpoint does not exist in Keycloak 26** — so the call failed and no user was ever added to `kronos-dev`. No membership → no `organization` claim → 401. (This never surfaced before because every earlier run crashed before `keycloak-init` ran.)

## Fix

Link members via the documented call (verified against the Keycloak Admin REST API and discussions [#34230](https://github.com/keycloak/keycloak/discussions/34230) / [#37542](https://github.com/keycloak/keycloak/discussions/37542)):

```
POST /admin/realms/{realm}/organizations/{id}/members
Content-Type: application/json
Body: "<userId>"          # the user id as a quoted JSON string
```

Accepts `201`/`204` (added) and `409` (already a member). Updated both `scripts/provision_keycloak_org.sh` and the chart-local copy (kept in sync).

## To apply (no full rebuild needed)

`keycloak-init` is idempotent and the script is bind-mounted, so just re-run it against the running stack, then **log out / log back in** to get a fresh token:

```
docker compose -f docker/docker-compose.dev.yml run --rm keycloak-init
```

(`make clean && make dev` is the guaranteed-clean path.) After re-login, the token should carry `{"kronos-dev": {"id": "..."}}` and `/api/cases` should return `200`.

## Caveat

I can verify the member-link is now the correct API, but not end-to-end here (no Docker). If the claim is still absent after re-login, the next thing to check is that the `organization` client scope is a **default** scope on `kronos-frontend` (it's in the realm `defaultDefaultClientScopes`, so imported clients should inherit it) — send the new token's decoded claims and I'll confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_