### PR TITLE
fix(auth): look up org by alias client-side + idempotent create (fixes exit 22 / missing org claim)

### DIFF
--- a/charts/kronos/files/provision_keycloak_org.sh
+++ b/charts/kronos/files/provision_keycloak_org.sh
@@ -34,7 +34,17 @@ ORG_DESCRIPTION="${ORG_DESCRIPTION:-}"
 ORG_DOMAIN="${ORG_DOMAIN:-}"
 ORG_MEMBER_IDS="${ORG_MEMBER_IDS:-}"
 
-extract_first_id() { grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4; }
+# The organizations 'search' param matches org name/domain, NOT alias, so list
+# all orgs and match the alias client-side. `tr '{'` puts each org's leading
+# fields (id..alias) on one line — before the nested domains '{' — so the id and
+# alias of the same org stay together on the matched line.
+find_org_id() {
+  curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations?first=0&max=1000" \
+    | tr '{' '\n' \
+    | grep "\"alias\":\"$ORG_ALIAS\"" \
+    | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4
+}
 
 echo "provision_keycloak_org: realm=$KC_REALM org=$ORG_ALIAS base=$KC_BASE"
 
@@ -65,8 +75,7 @@ if ! curl -sf -o /dev/null -H "Authorization: Bearer $TOKEN" "$KC_BASE/admin/rea
   exit 1
 fi
 
-ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-  "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+ORG_ID=$(find_org_id || true)
 
 if [ -z "$ORG_ID" ]; then
   echo "Creating organization $ORG_ALIAS"
@@ -75,13 +84,17 @@ if [ -z "$ORG_ID" ]; then
   else
     DOMAINS="[]"
   fi
-  curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  # No -f here: a 409 (org already exists, e.g. created by a prior run on a
+  # still-running Keycloak) must not abort the script — we resolve the id by
+  # alias afterwards either way.
+  HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
     "$KC_BASE/admin/realms/$KC_REALM/organizations" \
-    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}"
-  ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-    "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}" || true)
+  echo "create organization -> HTTP $HTTP"
+  ORG_ID=$(find_org_id || true)
 else
-  echo "Organization $ORG_ALIAS already exists"
+  echo "Organization $ORG_ALIAS already exists (id=$ORG_ID)"
 fi
 
 if [ -z "$ORG_ID" ]; then

--- a/scripts/provision_keycloak_org.sh
+++ b/scripts/provision_keycloak_org.sh
@@ -34,7 +34,17 @@ ORG_DESCRIPTION="${ORG_DESCRIPTION:-}"
 ORG_DOMAIN="${ORG_DOMAIN:-}"
 ORG_MEMBER_IDS="${ORG_MEMBER_IDS:-}"
 
-extract_first_id() { grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4; }
+# The organizations 'search' param matches org name/domain, NOT alias, so list
+# all orgs and match the alias client-side. `tr '{'` puts each org's leading
+# fields (id..alias) on one line — before the nested domains '{' — so the id and
+# alias of the same org stay together on the matched line.
+find_org_id() {
+  curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_BASE/admin/realms/$KC_REALM/organizations?first=0&max=1000" \
+    | tr '{' '\n' \
+    | grep "\"alias\":\"$ORG_ALIAS\"" \
+    | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4
+}
 
 echo "provision_keycloak_org: realm=$KC_REALM org=$ORG_ALIAS base=$KC_BASE"
 
@@ -65,8 +75,7 @@ if ! curl -sf -o /dev/null -H "Authorization: Bearer $TOKEN" "$KC_BASE/admin/rea
   exit 1
 fi
 
-ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-  "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+ORG_ID=$(find_org_id || true)
 
 if [ -z "$ORG_ID" ]; then
   echo "Creating organization $ORG_ALIAS"
@@ -75,13 +84,17 @@ if [ -z "$ORG_ID" ]; then
   else
     DOMAINS="[]"
   fi
-  curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  # No -f here: a 409 (org already exists, e.g. created by a prior run on a
+  # still-running Keycloak) must not abort the script — we resolve the id by
+  # alias afterwards either way.
+  HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
     "$KC_BASE/admin/realms/$KC_REALM/organizations" \
-    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}"
-  ORG_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
-    "$KC_BASE/admin/realms/$KC_REALM/organizations?search=$ORG_ALIAS" | extract_first_id)
+    -d "{\"name\":\"$ORG_NAME\",\"alias\":\"$ORG_ALIAS\",\"enabled\":true,\"description\":\"$ORG_DESCRIPTION\",\"domains\":$DOMAINS}" || true)
+  echo "create organization -> HTTP $HTTP"
+  ORG_ID=$(find_org_id || true)
 else
-  echo "Organization $ORG_ALIAS already exists"
+  echo "Organization $ORG_ALIAS already exists (id=$ORG_ID)"
 fi
 
 if [ -z "$ORG_ID" ]; then


### PR DESCRIPTION
## Where the error comes from

```
keycloak-init-1 | Creating organization kronos-dev
keycloak-init-1 exited with code 22
...
kronos-backend-1 | jwt_validation_failed: JWT is missing the 'organization' claim → 401
```

`curl` exit **22** = the org-create `POST` got an HTTP ≥400 (because of `curl -f`), and `set -e` aborted the script **before the member-link step** → users never joined the org → tokens carry no `organization` claim.

**Root cause:** the Keycloak organizations **`search` param matches the org name and domain, not the alias** (verified against the docs). The script looked the org up with `?search=kronos-dev`, which never matches (name is `KronOS Dev`, domain `kronos.dev`). So:

- Re-running `keycloak-init` against a still-running `dev-mem` Keycloak that already had the org → lookup misses → `POST` a duplicate → **409 Conflict** → `curl -f` exit 22 → abort.
- Even on a fresh Keycloak → the post-create lookup-by-alias *also* misses → empty `ORG_ID`.

(The decoded token you pasted is the `KEYCLOAK_IDENTITY` cookie — Keycloak's internal `Serialized-ID` session token — not the access token; the access token is the one missing the claim.)

## The config itself is correct

The realm's `organization` client scope + `oidc-organization-membership-mapper` (`addOrganizationId=true`, `multivalued`, JSON) produces `{"kronos-dev":{"id":"…"}}`, which is exactly what the backend's `_extract_tenant` reads. The only defect was the provisioning script.

## Fix

- `find_org_id()` — list all orgs and match the **alias client-side** (`tr '{'` keeps each org's `id`+`alias` together on one line, before the nested `domains` `{`). Unit-tested the parse against a 2-org sample: correct id per alias, empty for missing.
- **Create is now idempotent** — dropped `-f`, tolerate `409`, and resolve the id by alias afterwards regardless. Re-runs are safe.
- Updated both `scripts/provision_keycloak_org.sh` and the chart copy (in sync).

## To apply

```
docker compose -f docker/docker-compose.dev.yml run --rm keycloak-init   # now completes + adds members
```
then **log out / log back in**. (`make clean && make dev` is the clean path.) The new access token should contain `organization`, and `/api/cases` should return `200`.

If the claim is *still* missing after a confirmed-successful init (members linked) + fresh login, the remaining suspect is whether `organization` is actually applied as a default client scope on `kronos-frontend` — paste the decoded **access** token and I'll confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_