### PR TITLE
fix: Keycloak sub scope + 3 API contract bugs (cases/undefined, org/users 404, invite 405)

### DIFF
--- a/docker/keycloak/kronos-realm.json
+++ b/docker/keycloak/kronos-realm.json
@@ -157,6 +157,28 @@
       ]
     },
     {
+      "name": "kronos-sub",
+      "description": "Includes sub (user ID) in all token types including userinfo",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "sub-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
       "name": "organization",
       "description": "Organization context for multi-tenancy",
       "protocol": "openid-connect",
@@ -191,6 +213,7 @@
     "web-origins",
     "acr",
     "kronos-roles",
+    "kronos-sub",
     "organization"
   ],
   "defaultOptionalClientScopes": [

--- a/src/external/routes/admin.py
+++ b/src/external/routes/admin.py
@@ -80,7 +80,7 @@ async def list_org_users(
     return OrgUsersResponse(items=users, total=len(users))
 
 
-@router.post("/invite", status_code=status.HTTP_201_CREATED)
+@router.post("/users/invite", status_code=status.HTTP_201_CREATED)
 async def invite_user(
     body: InviteUserIn,
     tenant: Annotated[TenantContext, Depends(requires_role(*_ADMIN_ROLES))],
@@ -92,7 +92,7 @@ async def invite_user(
         await _keycloak_admin_request(
             tenant,
             "POST",
-            f"/orgs/{tenant.org_id}/members/invite",
+            f"/organizations/{tenant.org_id}/members/invite",
             {"email": body.email, "roles": [body.role]},
         )
     except StorageError as exc:
@@ -120,7 +120,7 @@ async def update_user_role(
         await _keycloak_admin_request(
             tenant,
             "PATCH",
-            f"/orgs/{tenant.org_id}/members/{user_id}/roles",
+            f"/organizations/{tenant.org_id}/members/{user_id}/roles",
             {"roles": [body.role]},
         )
     except StorageError as exc:
@@ -147,7 +147,7 @@ async def remove_user(
         await _keycloak_admin_request(
             tenant,
             "DELETE",
-            f"/orgs/{tenant.org_id}/members/{user_id}",
+            f"/organizations/{tenant.org_id}/members/{user_id}",
             None,
         )
     except StorageError as exc:
@@ -254,7 +254,7 @@ async def _keycloak_admin_request(
             context={"error": str(exc)},
         ) from exc
 
-    admin_url = f"{settings.keycloak_url}/realms/{settings.keycloak_realm}/admin{path}"
+    admin_url = f"{settings.keycloak_url}/admin/realms/{settings.keycloak_realm}{path}"
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.request(
@@ -269,7 +269,7 @@ async def _keycloak_admin_request(
                     context={"status": resp.status_code},
                 )
             if resp.status_code == 404:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found in org")
+                raise StorageError("Resource not found in Keycloak", context={"status": 404})
             resp.raise_for_status()
     except httpx.HTTPError as exc:
         raise StorageError(
@@ -282,7 +282,7 @@ async def _keycloak_admin_request(
 
 async def _list_keycloak_org_users(tenant: TenantContext) -> list[OrgUserOut]:
     """Fetch org members from Keycloak."""
-    data = await _keycloak_admin_request(tenant, "GET", f"/orgs/{tenant.org_id}/members", None)
+    data = await _keycloak_admin_request(tenant, "GET", f"/organizations/{tenant.org_id}/members", None)
     if not isinstance(data, list):
         return []
     return [

--- a/src/external/routes/cases.py
+++ b/src/external/routes/cases.py
@@ -42,21 +42,25 @@ class CreateCaseIn(BaseModel):
 
 
 class CaseOut(BaseModel):
-    case_id: uuid.UUID
-    org_id: uuid.UUID
+    """API response DTO — field names match the frontend TypeScript Case interface."""
+
+    id: uuid.UUID
+    orgId: uuid.UUID
     title: str
     description: str | None
-    reference_number: str | None
+    reference: str | None
     status: str
-    created_at: str
-    updated_at: str
+    createdAt: str
+    updatedAt: str
+    createdBy: str
+    evidenceCount: int = 0
 
 
 class PaginatedCases(BaseModel):
     items: list[CaseOut]
     total: int
     page: int
-    page_size: int
+    pageSize: int
 
 
 class EvidenceListItem(BaseModel):
@@ -134,7 +138,7 @@ async def list_cases(
         items=[_to_case_out(c) for c in cases],
         total=total,
         page=page,
-        page_size=page_size,
+        pageSize=page_size,
     )
 
 
@@ -259,12 +263,13 @@ async def get_dashboard_url(
 
 def _to_case_out(case: Case) -> CaseOut:
     return CaseOut(
-        case_id=case.case_id,
-        org_id=case.org_id,
+        id=case.case_id,
+        orgId=case.org_id,
         title=case.metadata.title,
         description=case.metadata.description,
-        reference_number=case.metadata.reference_number,
+        reference=case.metadata.reference_number,
         status=case.status.value,
-        created_at=case.created_at.isoformat(),
-        updated_at=case.updated_at.isoformat(),
+        createdAt=case.created_at.isoformat(),
+        updatedAt=case.updated_at.isoformat(),
+        createdBy=str(case.owner_user_id),
     )


### PR DESCRIPTION
## Summary

- Add `kronos-sub` Keycloak client scope (explicit `sub` claim in all token types including userinfo) and register it in `defaultDefaultClientScopes`
- Fix `GET /api/cases/undefined` (422): backend `CaseOut` field names were snake_case while the frontend expected camelCase — `c.id` was `undefined`, producing the bad URL
- Fix `GET /api/admin/org/users` (404): Keycloak Admin REST URL was constructed in the wrong order (`/realms/{r}/admin` instead of `/admin/realms/{r}`), paths used `/orgs/` instead of `/organizations/`, and a Keycloak 404 was re-raised as `HTTPException(404)` escaping the `StorageError` catch
- Fix `POST /api/admin/org/users/invite` (405): backend route was `/invite`, frontend called `/users/invite`; FastAPI matched `/users/{user_id}` (PATCH/DELETE only) → 405

## Changes

### `docker/keycloak/kronos-realm.json`
- New `kronos-sub` client scope with `oidc-sub-mapper` enabled for access token, id token, and userinfo
- Added `kronos-sub` to `defaultDefaultClientScopes`

### `src/external/routes/cases.py`
- `CaseOut`: renamed fields to match frontend TypeScript `Case` interface (`id`, `orgId`, `reference`, `createdAt`, `updatedAt`, `createdBy`, `evidenceCount`)
- `PaginatedCases`: renamed `page_size` → `pageSize` to match frontend `PaginatedResponse`
- `_to_case_out()`: updated to use new field names

### `src/external/routes/admin.py`
- `_keycloak_admin_request`: fixed URL from `{kc}/realms/{r}/admin{path}` → `{kc}/admin/realms/{r}{path}`
- All org member paths: `/orgs/{id}/members` → `/organizations/{id}/members`
- Keycloak 404 response: now raises `StorageError` (caught upstream) instead of `HTTPException(404)` (which was not caught)
- Invite route: `/invite` → `/users/invite`

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_