### PR TITLE
fix(admin): org-users response shape + Keycloak step-up MFA flow

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -2,8 +2,8 @@ import apiClient from './client'
 import type { OrgUser, OrgSettings, Role } from '../types'
 
 export async function getOrgUsers(): Promise<OrgUser[]> {
-  const res = await apiClient.get<OrgUser[]>('/api/admin/org/users')
-  return res.data
+  const res = await apiClient.get<{ items: OrgUser[]; total: number }>('/api/admin/org/users')
+  return res.data.items
 }
 
 export async function inviteUser(email: string, role: Role): Promise<OrgUser> {

--- a/src/external/routes/admin.py
+++ b/src/external/routes/admin.py
@@ -30,11 +30,13 @@ _ADMIN_ROLES = (Role.ORG_ADMIN,)
 
 
 class OrgUserOut(BaseModel):
-    user_id: str
+    """API response DTO — field names match the frontend TypeScript OrgUser interface."""
+
+    userId: str
     username: str
     email: str
     roles: list[str]
-    joined_at: str | None
+    joinedAt: str | None
 
 
 class OrgUsersResponse(BaseModel):
@@ -132,7 +134,7 @@ async def update_user_role(
         actor_user_id=tenant.user_id,
         details={"target_user_id": user_id, "new_role": body.role},
     )
-    return OrgUserOut(user_id=user_id, username="", email="", roles=[body.role], joined_at=None)
+    return OrgUserOut(userId=user_id, username="", email="", roles=[body.role], joinedAt=None)
 
 
 @router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -287,11 +289,11 @@ async def _list_keycloak_org_users(tenant: TenantContext) -> list[OrgUserOut]:
         return []
     return [
         OrgUserOut(
-            user_id=u.get("id", ""),
+            userId=u.get("id", ""),
             username=u.get("username", ""),
             email=u.get("email", ""),
             roles=u.get("roles", []),
-            joined_at=u.get("createdTimestamp"),
+            joinedAt=u.get("createdTimestamp"),
         )
         for u in data
     ]


### PR DESCRIPTION
## Summary

**1. Org-users list crash (`n.map is not a function`)**
- `GET /api/admin/org/users` returns `{ items: [...], total }` (`OrgUsersResponse`), but the frontend typed the response as a bare `OrgUser[]` and called `.map()` directly on it in `AdminPage.tsx`.
- `OrgUserOut` also serialized snake_case fields (`user_id`, `joined_at`) while the frontend `OrgUser` type expects camelCase (`userId`, `joinedAt`).
- Fix: `src/external/routes/admin.py` renames `OrgUserOut` fields to camelCase; `frontend/src/api/admin.ts` unwraps `res.data.items`.

**2. Step-up auth (`acr=aal2`) never actually elevates — invite/role-change/remove stuck in a 401 loop**
- The backend correctly issues `401 insufficient_user_authentication` with `acr_values="aal2"` for org-admin mutations (RFC 9470), and the SPA correctly replays via `keycloak.login({ acrValues: 'aal2' })`.
- But the realm had no authentication flow wired to honor the requested ACR or write `acr` into the resulting token, and none of the dev users have a second factor configured. So the step-up redirect just re-ran a plain password login and the invite request kept 401ing forever.
- This is a previously-flagged design gap (`reviews/Part_6_Review.md`, finding P6: "No MFA / step-up plan").
- Fix: `docker/keycloak/kronos-realm.json` adds a `browser-stepup` authentication flow with a `Condition - Level of Authentication` execution gated on `acr.loa.map` level 2 — OTP is only required when `acr_values=aal2` is actually requested. The `admin` dev user now has `CONFIGURE_TOTP` as a required action so they enroll a TOTP secret on first step-up challenge.

## Files changed

- `src/external/routes/admin.py` — `OrgUserOut` camelCase fields
- `frontend/src/api/admin.ts` — unwrap `items` from the paginated response
- `docker/keycloak/kronos-realm.json` — `browser-stepup` conditional-MFA flow, `admin` user `CONFIGURE_TOTP` required action

## Test plan

- [ ] Load `/admin/org` as an org-admin user and confirm the user table renders without a client-side error
- [ ] Click "Invite User" — Keycloak should redirect for step-up; on first attempt the `admin` user should be prompted to scan a TOTP QR code and enroll
- [ ] After completing OTP, confirm the SPA replays the invite request and it succeeds (no more infinite 401 loop)
- [ ] Confirm a normal (non-step-up) login still works without being forced into MFA