### PR TITLE
fix(keycloak): wire conditional MFA flow so step-up auth (acr=aal2) actually works

### DIFF
--- a/docker/keycloak/kronos-realm.json
+++ b/docker/keycloak/kronos-realm.json
@@ -24,6 +24,7 @@
     "acr.loa.map": "{\"aal1\":1,\"aal2\":2}"
   },
   "refreshTokenMaxReuse": 0,
+  "browserFlow": "browser-stepup",
   "roles": {
     "realm": [
       {
@@ -211,6 +212,94 @@
       ]
     }
   ],
+  "authenticationFlows": [
+    {
+      "alias": "browser-stepup",
+      "description": "Browser-based authentication with conditional step-up MFA (RFC 9470, acr_values=aal2).",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "flowAlias": "browser-stepup forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "browser-stepup forms",
+      "description": "Username/password, then conditional MFA depending on the requested ACR level.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "browser-stepup conditional-mfa",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "browser-stepup conditional-mfa",
+      "description": "Enforces TOTP when the auth request asks for aal2 (level 2 in acr.loa.map).",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-level-of-authentication",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false,
+          "authenticatorConfig": "browser-stepup loa-2"
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": true,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "alias": "browser-stepup loa-2",
+      "config": {
+        "level": "2",
+        "max_age": "0"
+      }
+    }
+  ],
   "defaultDefaultClientScopes": [
     "roles",
     "profile",
@@ -244,7 +333,7 @@
         }
       ],
       "realmRoles": ["org-admin"],
-      "requiredActions": []
+      "requiredActions": ["CONFIGURE_TOTP"]
     },
     {
       "id": "10000000-0000-4000-8000-000000000002",


### PR DESCRIPTION
## Summary

Step-up auth (`acr=aal2`) never actually elevated — org-admin mutations like inviting a user got stuck in an infinite 401 loop.

- The backend correctly issues `401 insufficient_user_authentication` with `acr_values="aal2"` for org-admin mutations (RFC 9470), and the SPA correctly replays via `keycloak.login({ acrValues: 'aal2' })`.
- But the realm had no authentication flow wired to honor the requested ACR or write `acr` into the resulting token, and none of the dev users have a second factor configured. So the step-up redirect just re-ran a plain password login, the new token still had no `acr` claim, and the original request kept 401ing.
- This is a previously-flagged design gap (`reviews/Part_6_Review.md`, finding P6: "No MFA / step-up plan") — the backend/frontend contract was built, but the realm-side Conditional-MFA flow was never implemented.

## Fix

`docker/keycloak/kronos-realm.json`:
- Adds a `browser-stepup` authentication flow (set as the realm's `browserFlow`) with a `Condition - Level of Authentication` execution gated on `acr.loa.map` level 2 — OTP is only required when `acr_values=aal2` is actually requested, not on every login.
- The `admin` dev user now has `CONFIGURE_TOTP` as a required action, so they enroll a TOTP secret the first time they hit a step-up challenge.

## Test plan

- [ ] Fresh realm import (new Postgres/Keycloak volume) picks up the new `browser-stepup` flow without errors
- [ ] Normal login (no step-up requested) still works without being forced into MFA
- [ ] Org-admin action (e.g. invite user) triggers a 401, SPA redirects to Keycloak for step-up
- [ ] `admin` user is prompted to scan a TOTP QR code and enroll on first step-up attempt
- [ ] After completing OTP, the SPA replays the original request and it succeeds (no more infinite 401 loop)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujRDNTNRpesEUnR3jq8uU)_