### PR TITLE
fix(docker): add USER root to Chainguard builder stages (INFRA-005 fo…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,13 @@
 # project's reference pattern for Chainguard images (INFRA-005).
 FROM cgr.dev/chainguard/python:latest-dev AS builder
 
+# Chainguard images run as the built-in "nonroot" user by default — even the
+# "-dev" variants — so /opt (and any other root-owned path) isn't writable
+# without this. Safe here: this is a discarded builder stage in a
+# multi-stage build: root privileges never reach the runtime image below,
+# which still explicitly runs as USER nonroot.
+USER root
+
 WORKDIR /app
 COPY pyproject.toml .
 COPY src/ ./src/

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -2,6 +2,11 @@
 # the shell + npm needed to build; mirrors docker/plaso/Dockerfile, this
 # project's reference pattern for Chainguard images.
 FROM cgr.dev/chainguard/node:latest-dev AS builder
+# Chainguard images run as the built-in "nonroot" user by default — even the
+# "-dev" variants — so WORKDIR/npm ci below would fail writing under
+# root-owned /app without this. Safe here: this is a discarded builder stage
+# in a multi-stage build; the runtime stage below still runs as USER nginx.
+USER root
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci

--- a/docker/plaso/Dockerfile
+++ b/docker/plaso/Dockerfile
@@ -1,5 +1,11 @@
 FROM cgr.dev/chainguard/python:latest-dev AS build
 
+# Chainguard images run as the built-in "nonroot" user by default — even the
+# "-dev" variants — so /opt isn't writable without this. Safe here: this is
+# a discarded builder stage in a multi-stage build; the runtime stage below
+# still runs as USER nonroot.
+USER root
+
 # Install Plaso and its dependencies into a virtual environment.
 RUN python -m venv /opt/plaso-venv
 ENV PATH="/opt/plaso-venv/bin:${PATH}"
@@ -10,10 +16,10 @@ FROM cgr.dev/chainguard/python:latest
 LABEL org.opencontainers.image.title="KronOS Plaso Worker"
 LABEL org.opencontainers.image.description="Heavy forensic parser — Plaso in Firecracker-compatible container"
 
-COPY --from=build /opt/plaso-venv /opt/plaso-venv
+COPY --from=build --chown=nonroot:nonroot /opt/plaso-venv /opt/plaso-venv
 ENV PATH="/opt/plaso-venv/bin:${PATH}"
 
-COPY kronos-plaso-worker.py /app/kronos-plaso-worker.py
+COPY --chown=nonroot:nonroot kronos-plaso-worker.py /app/kronos-plaso-worker.py
 
 WORKDIR /app
 USER nonroot


### PR DESCRIPTION
…llow-up)

docker compose build --no-cache failed with "Permission denied: '/opt/venv'" on kronos-backend/celery-worker/celery-beat, and would have hit the same class of failure on nginx's npm ci step (frontend Dockerfile) and docker/plaso/Dockerfile's venv creation.

Root cause: Chainguard container images run as the built-in "nonroot" user by default — including the "-dev" variants used as builder stages — so writes under root-owned paths like /opt or a freshly-created WORKDIR fail. This couldn't be caught by static review alone; it only surfaces on an actual `docker build`, which wasn't available when the Chainguard rebase (INFRA-005) was done.

Fix: explicit `USER root` at the top of each builder stage, before any venv/pip/npm install steps. Safe — these are discarded multi-stage build layers; every runtime stage already correctly declares USER nonroot/nginx, so nothing ships less-hardened. Also added the matching --chown=nonroot on plaso's final COPY --from=build, which was copying a now-root-owned venv into a USER nonroot runtime stage without it (same risk class, previously masked because the builder ran as root's predecessor semantics only by coincidence prior to this fix).


Claude-Session: https://claude.ai/code/session_01MbsZVuTgxjdTFkQcZKA2SG