### PR TITLE
fix(docker): pin plaso to a real released version, not a fabricated one

### DIFF
--- a/docker/Dockerfile.plaso-worker
+++ b/docker/Dockerfile.plaso-worker
@@ -17,7 +17,7 @@ COPY kronos_attest/ ./kronos_attest/
 RUN python -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir --upgrade pip \
     && /opt/venv/bin/pip install --no-cache-dir . \
-    && /opt/venv/bin/pip install --no-cache-dir plaso==20240101
+    && /opt/venv/bin/pip install --no-cache-dir plaso==20260512
 
 RUN mkdir -p /var/log/kronos && touch /var/log/kronos/.keep
 

--- a/docker/plaso/Dockerfile
+++ b/docker/plaso/Dockerfile
@@ -9,7 +9,7 @@ USER root
 # Install Plaso and its dependencies into a virtual environment.
 RUN python -m venv /opt/plaso-venv
 ENV PATH="/opt/plaso-venv/bin:${PATH}"
-RUN pip install --no-cache-dir plaso==20240101 || pip install --no-cache-dir plaso
+RUN pip install --no-cache-dir plaso==20260512
 
 FROM cgr.dev/chainguard/python:latest
 

--- a/src/external/parsers/plaso.py
+++ b/src/external/parsers/plaso.py
@@ -50,7 +50,7 @@ class PlasoParser(ForensicParser):
 
     @property
     def parser_version(self) -> str:
-        return "20240101"
+        return "20260512"
 
     @property
     def parser_type(self) -> ParserType:

--- a/src/external/sandbox/firecracker.py
+++ b/src/external/sandbox/firecracker.py
@@ -55,7 +55,7 @@ class FirecrackerLauncher:
         org_alias: str,
         sha256: str,
         parser_name: str = "plaso",
-        parser_version: str = "20240101",
+        parser_version: str = "20260512",
     ) -> AsyncIterator[TimelineRecord]:
         """Yield TimelineRecord objects from Plaso parsing of evidence_path."""
         cmd = [


### PR DESCRIPTION
celery-worker-plaso failed to build: pip could not find plaso==20240101 because that version was never released — PyPI has no 2024-01-01 plaso build (nearest real releases are 20231224 and 20240308). The pin was a fabricated placeholder that happened to match plaso's YYYYMMDD version scheme but didn't correspond to an actual release, so the venv install step in docker/Dockerfile.plaso-worker always failed at the last package.

Repinned to plaso==20260512, the latest real release on PyPI. Verified via `pip install --dry-run` that the full dependency graph (dfvfs, dfwinreg, acstore, dtfabric, ~40 libyal-python bindings, pytsk3, etc.) resolves cleanly with no version conflicts against kronos's own pinned deps, and that manylinux wheels exist for the libyal C-extension packages (avoiding a from-source compile requirement).

Also fixed the same fabricated pin in docker/plaso/Dockerfile (an older, currently-unused standalone image), removing its silent `|| pip install plaso` fallback — a forensic evidence pipeline shouldn't silently drift to an unpinned version on failure.

Updated PlasoParser.parser_version and FirecrackerLauncher's default parser_version from "20240101" to "20260512" so the chain-of-custody provenance recorded on TimelineRecords matches the Plaso version actually doing the parsing.

Verified: full unit suite still passes (492 passed).


Claude-Session: https://claude.ai/code/session_0199gzPPi6XqSrEWoMxnc12K